### PR TITLE
bump max ticks for retrying fishing from 100 -> 1000

### DIFF
--- a/src/main/java/net/wurstclient/hacks/AutoFishHack.java
+++ b/src/main/java/net/wurstclient/hacks/AutoFishHack.java
@@ -59,7 +59,7 @@ public final class AutoFishHack extends Hack
 	private final SliderSetting retryDelay = new SliderSetting("Retry delay",
 		"If casting or reeling in the fishing rod fails, this is how long"
 			+ " AutoFish will wait before trying again.",
-		15, 0, 100, 1,
+		15, 0, 1000, 1,
 		ValueDisplay.INTEGER.withSuffix(" ticks").withLabel(1, "1 tick"));
 	
 	private final SliderSetting patience = new SliderSetting("Patience",


### PR DESCRIPTION


## Description
Bumping retryTick ceiling for AutoFishing

Currently 100 can be too short and the retry happens prematurely, especially if the rod is not enchanted. Bumping to 1000 (50 seconds) - to give users more control

## Testing
Did not test

## References
Experienced the issue myself
